### PR TITLE
fix: configuring CSRF_TRUSTED_ORIGINS for kurtosis cloud

### DIFF
--- a/app/files/mysite/mysite/settings.py
+++ b/app/files/mysite/mysite/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = 'django-insecure-rw&hze^c#g8%f!bbplm7!%(^yryd9m&rjbho(31%rpgi#^9y1*
 DEBUG = True
 
 ALLOWED_HOSTS = ["*"]
-CSRF_TRUSTED_ORIGINS = ['http://*.on-acorn.io','https://*.on-acorn.io']
+CSRF_TRUSTED_ORIGINS = ['http://*.kurtosis.com','https://*.kurtosis.com']
 
 # Application definition
 


### PR DESCRIPTION
This will allow us to run fully run the package in Kurtosis cloud